### PR TITLE
Fix nested array keys

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.github.wistefan</groupId>
     <artifactId>ngsi-ld-java-mapping</artifactId>
-    <version>1.6.14-SNAPSHOT</version>
+    <version>1.1.0</version>
     <packaging>jar</packaging>
 
     <developers>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.github.wistefan</groupId>
     <artifactId>ngsi-ld-java-mapping</artifactId>
-    <version>1.1.0</version>
+    <version>1.6.14-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <developers>

--- a/src/main/java/io/github/wistefan/mapping/EntityVOMapper.java
+++ b/src/main/java/io/github/wistefan/mapping/EntityVOMapper.java
@@ -297,19 +297,16 @@ public class EntityVOMapper extends Mapper {
 	}
 
 	/**
-	 * NGSI-LD brokers are allowed to compact a multi-instance Property that
-	 * happens to have only one instance back to a single Property in the
-	 * response (the array wrapper is dropped). When {@link JavaObjectMapper}
-	 * persists a plain-value list it tags every {@code PropertyVO} with a
-	 * synthetic {@code datasetId} prefixed by
-	 * {@link JavaObjectMapper#LIST_ITEM_DATASET_ID_PREFIX} — if we see that
-	 * prefix on a Property that came back as a scalar, the original input was
-	 * a single-element list and we have to wrap the value in one again.
+	 * Per NGSI-LD semantics a {@code PropertyVO} bearing a {@code datasetId}
+	 * is one instance of a multi-instance attribute — i.e. one item of a
+	 * list. When the broker compacts a multi-instance attribute that holds a
+	 * single instance the array wrapper is dropped on the wire, but the
+	 * {@code datasetId} survives, so any non-null value here signals that
+	 * the original input was a list and we have to wrap the scalar value in
+	 * a single-element {@link List} on the way back.
 	 */
 	private static boolean isCollapsedSingletonListItem(PropertyVO propertyVO) {
-		URI datasetId = propertyVO.getDatasetId();
-		return datasetId != null
-				&& datasetId.toString().startsWith(JavaObjectMapper.LIST_ITEM_DATASET_ID_PREFIX);
+		return propertyVO.getDatasetId() != null;
 	}
 
 	private Map.Entry<String, Object> fromProperty(String key, PropertyVO propertyVO) {

--- a/src/main/java/io/github/wistefan/mapping/EntityVOMapper.java
+++ b/src/main/java/io/github/wistefan/mapping/EntityVOMapper.java
@@ -249,7 +249,7 @@ public class EntityVOMapper extends Mapper {
 
 	private UnmappedProperty toUnmappedProperty(Map.Entry<String, AdditionalPropertyVO> unmappedAdditionalProperty) {
 		UnmappedProperty unmappedProperty = new UnmappedProperty();
-		unmappedProperty.setName(unmappedAdditionalProperty.getKey());
+		unmappedProperty.setName(ReservedWordHandler.removeEscape(unmappedAdditionalProperty.getKey()));
 
 		if (unmappedAdditionalProperty.getValue() instanceof PropertyListVO propertyListVO) {
 			unmappedProperty.setValue(
@@ -278,9 +278,9 @@ public class EntityVOMapper extends Mapper {
 					.stream()
 					.map(entry -> {
 						if (entry.getValue() instanceof PropertyVO pvo) {
-							return fromProperty(entry.getKey(), pvo);
+							return fromProperty(ReservedWordHandler.removeEscape(entry.getKey()), pvo);
 						} else if (entry.getValue() instanceof RelationshipVO rvo) {
-							return fromRelationship(entry.getKey(), rvo);
+							return fromRelationship(ReservedWordHandler.removeEscape(entry.getKey()), rvo);
 						} else {
 							throw new MappingException(String.format("Entry value is not supported. Was: %s", entry.getValue()));
 						}
@@ -296,21 +296,37 @@ public class EntityVOMapper extends Mapper {
 		}
 	}
 
+	/**
+	 * NGSI-LD brokers are allowed to compact a multi-instance Property that
+	 * happens to have only one instance back to a single Property in the
+	 * response (the array wrapper is dropped). When {@link JavaObjectMapper}
+	 * persists a plain-value list it tags every {@code PropertyVO} with a
+	 * synthetic {@code datasetId} prefixed by
+	 * {@link JavaObjectMapper#LIST_ITEM_DATASET_ID_PREFIX} — if we see that
+	 * prefix on a Property that came back as a scalar, the original input was
+	 * a single-element list and we have to wrap the value in one again.
+	 */
+	private static boolean isCollapsedSingletonListItem(PropertyVO propertyVO) {
+		URI datasetId = propertyVO.getDatasetId();
+		return datasetId != null
+				&& datasetId.toString().startsWith(JavaObjectMapper.LIST_ITEM_DATASET_ID_PREFIX);
+	}
+
 	private Map.Entry<String, Object> fromProperty(String key, PropertyVO propertyVO) {
 		if (propertyVO.getAdditionalProperties() != null && !propertyVO.getAdditionalProperties().isEmpty()) {
 			return new AbstractMap.SimpleEntry<>(key, propertyVO.getAdditionalProperties().entrySet()
 					.stream()
 					.map(entry -> {
 						if (entry.getValue() instanceof PropertyVO pvo) {
-							return fromProperty(entry.getKey(), pvo);
+							return fromProperty(ReservedWordHandler.removeEscape(entry.getKey()), pvo);
 						} else if (entry.getValue() instanceof RelationshipVO rvo) {
-							return fromRelationship(entry.getKey(), rvo);
+							return fromRelationship(ReservedWordHandler.removeEscape(entry.getKey()), rvo);
 						} else if (entry.getValue() instanceof PropertyListVO plvo) {
 							List<Object> valueList = plvo.stream()
 									.map(pvo -> fromProperty(entry.getKey(), pvo))
 									.map(Map.Entry::getValue)
 									.toList();
-							return new AbstractMap.SimpleEntry<>(key, valueList);
+							return new AbstractMap.SimpleEntry<>(ReservedWordHandler.removeEscape(entry.getKey()), valueList);
 						} else {
 							throw new MappingException(String.format("Entry value is not supported. Was: %s", entry.getValue()));
 						}
@@ -318,7 +334,11 @@ public class EntityVOMapper extends Mapper {
 					.filter(entry -> entry.getValue() != null)
 					.collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
 		} else {
-			return new AbstractMap.SimpleEntry<>(key, propertyVO.getValue());
+			Object value = propertyVO.getValue();
+			if (isCollapsedSingletonListItem(propertyVO)) {
+				value = List.of(value);
+			}
+			return new AbstractMap.SimpleEntry<>(key, value);
 		}
 	}
 

--- a/src/main/java/io/github/wistefan/mapping/EscapeCleaningParser.java
+++ b/src/main/java/io/github/wistefan/mapping/EscapeCleaningParser.java
@@ -9,6 +9,13 @@ import java.io.IOException;
 /**
  * Implementation of the JsonParser, that cleans json-key's that are escaped to comply with NGSI-LD.
  * An entry "tmfEscaped-@id": "my-id" will become "@id":"my-id" after the cleaning.
+ *
+ * Keys whose unescaped form would collide with an explicit setter on the
+ * generated VOs (see {@link ReservedWordHandler#canUnescapeDuringParsing(String)})
+ * are kept escaped: Jackson would otherwise route them to the structural field
+ * (e.g. {@code PropertyVO.value}) and overwrite it, dropping the entry from
+ * {@code additionalProperties}. Those keys are stripped of their prefix later,
+ * in {@code EntityVOMapper}, when the user-facing keys are surfaced.
  */
 public class EscapeCleaningParser extends JsonParserDelegate {
 
@@ -18,13 +25,22 @@ public class EscapeCleaningParser extends JsonParserDelegate {
 
 	@Override
 	public String getCurrentName() throws IOException {
-		return ReservedWordHandler.removeEscape(super.currentName());
+		return cleanName(super.currentName());
 	}
 
 	@Override
 	public String currentName() throws IOException {
-		return ReservedWordHandler.removeEscape(super.currentName());
+		return cleanName(super.currentName());
 	}
 
+	private static String cleanName(String name) {
+		if (name == null) {
+			return null;
+		}
+		if (ReservedWordHandler.canUnescapeDuringParsing(name)) {
+			return ReservedWordHandler.removeEscape(name);
+		}
+		return name;
+	}
 
 }

--- a/src/main/java/io/github/wistefan/mapping/JavaObjectMapper.java
+++ b/src/main/java/io/github/wistefan/mapping/JavaObjectMapper.java
@@ -28,6 +28,16 @@ public class JavaObjectMapper extends Mapper {
 
 	// name of the property containing the ID
 	private static final String ID_PROPERTY = "id";
+
+	/**
+	 * URN prefix for synthetic datasetIds attached to each item of a plain-list
+	 * value persisted as a {@code PropertyListVO}. The datasetIds give each item
+	 * the multi-instance Property semantics that NGSI-LD brokers must preserve
+	 * — without them, a single-element array inside {@code Property.value} can
+	 * be compacted to its scalar form on retrieval (JSON-LD compaction).
+	 */
+	public static final String LIST_ITEM_DATASET_ID_PREFIX = "urn:ngsi-ld:dataset:list-item:";
+
 	private final MappingProperties mappingProperties;
 	private final ObjectMapper objectMapper;
 
@@ -407,9 +417,32 @@ public class JavaObjectMapper extends Mapper {
 
 
 	private AdditionalPropertyVO objectToAdditionalProperty(Object o) {
+		if (o instanceof List<?> objectList && objectList.isEmpty()) {
+			// Preserve empty arrays as empty arrays on the wire.
+			// Without this, the empty list would fall through to the Map branch
+			// below (toMap on a Collection returns Map.of()) and be persisted as
+			// an empty object {}, which fails to round-trip back to a List.
+			return new PropertyVO().value(new ArrayList<>());
+		}
 		if (o instanceof List<?> objectList && !objectList.isEmpty()) {
 			if (isPlain(objectList.get(0))) {
-				return new PropertyVO().value(listToEscapedMap(objectList));
+				// Use a PropertyListVO with synthetic datasetIds (one per item)
+				// instead of a single Property carrying a JSON array as its value.
+				// Otherwise NGSI-LD brokers may compact a single-element array to
+				// its scalar form on retrieval (JSON-LD compaction is allowed for
+				// values inside Property.value), which loses the array shape and
+				// breaks round-trip. A Property with multiple instances (one per
+				// datasetId) is the canonical NGSI-LD way to express a list of
+				// values; brokers must preserve every instance as a separate
+				// Property in the response.
+				PropertyListVO list = new PropertyListVO();
+				for (int i = 0; i < objectList.size(); i++) {
+					PropertyVO p = new PropertyVO();
+					p.setValue(objectList.get(i));
+					p.setDatasetId(URI.create(LIST_ITEM_DATASET_ID_PREFIX + i));
+					list.add(p);
+				}
+				return list;
 			} else {
 				PropertyListVO propertyVOS = new PropertyListVO();
 				RelationshipListVO relationshipVOS = new RelationshipListVO();

--- a/src/main/java/io/github/wistefan/mapping/JavaObjectMapper.java
+++ b/src/main/java/io/github/wistefan/mapping/JavaObjectMapper.java
@@ -36,7 +36,7 @@ public class JavaObjectMapper extends Mapper {
 	 * — without them, a single-element array inside {@code Property.value} can
 	 * be compacted to its scalar form on retrieval (JSON-LD compaction).
 	 */
-	public static final String LIST_ITEM_DATASET_ID_PREFIX = "urn:ngsi-ld:dataset:list-item:";
+	private static final String LIST_ITEM_DATASET_ID_PREFIX = "urn:ngsi-ld:dataset:list-item:";
 
 	private final MappingProperties mappingProperties;
 	private final ObjectMapper objectMapper;

--- a/src/main/java/io/github/wistefan/mapping/ReservedWordHandler.java
+++ b/src/main/java/io/github/wistefan/mapping/ReservedWordHandler.java
@@ -24,6 +24,20 @@ public class ReservedWordHandler {
 	private static final List<String> RESERVED_WORDS = List.of("id", "@id", "value", "@value", "type", "@type", "context", "@context");
 
 	/**
+	 * Subset of {@link #RESERVED_WORDS} whose JSON name (after unescape) would
+	 * collide with an explicit setter on the generated NGSI-LD VOs
+	 * ({@code PropertyVO.value}, {@code PropertyVO.type}, {@code EntityVO.id}, …).
+	 *
+	 * When such a name appears as an additional attribute on the wire (i.e. with
+	 * the {@link #ESCAPE_PREFIX}), the {@link EscapeCleaningParser} must leave the
+	 * prefix in place so Jackson routes the entry through {@code @JsonAnySetter}
+	 * into {@code additionalProperties} instead of overwriting the structural field.
+	 * The unescape then happens later — in {@code EntityVOMapper} — when emitting
+	 * the user-facing keys.
+	 */
+	private static final List<String> VO_FIELD_COLLISIONS = List.of("value", "type", "id");
+
+	/**
 	 * Prefix to be used for escaping the reserved words.
 	 */
 	private static final String ESCAPE_PREFIX = "tmfEscaped-";
@@ -64,6 +78,27 @@ public class ReservedWordHandler {
 			return w;
 		}
 		return key;
+	}
+
+	/**
+	 * Whether the given (potentially escaped) key should be unescaped during
+	 * JSON parsing — i.e. it is safe to surface the original name at the Jackson
+	 * field-resolution stage without colliding with an explicit setter on a VO.
+	 *
+	 * Returns {@code false} for keys whose unescaped form is in
+	 * {@link #VO_FIELD_COLLISIONS}: those must keep the {@link #ESCAPE_PREFIX}
+	 * until {@code EntityVOMapper} surfaces them, otherwise Jackson would route
+	 * the entry to the structural field instead of {@code @JsonAnySetter}.
+	 *
+	 * @param key the key as it arrives from the broker (possibly escaped)
+	 * @return true if the parser may safely strip the escape prefix
+	 */
+	public static boolean canUnescapeDuringParsing(String key) {
+		if (!isReservedProperty(key)) {
+			return false;
+		}
+		String unescaped = key.replaceFirst(ESCAPE_PREFIX, "");
+		return !VO_FIELD_COLLISIONS.contains(unescaped);
 	}
 
 }

--- a/src/test/java/io/github/wistefan/mapping/desc/EntityVOMapperTest.java
+++ b/src/test/java/io/github/wistefan/mapping/desc/EntityVOMapperTest.java
@@ -195,6 +195,150 @@ class EntityVOMapperTest {
 		assertEquals(expectedPojo, myPojoWithUnmappedProperties, "The full pojo should be returned.");
 	}
 
+	@DisplayName("Reconstruct a single-element list from a Property the broker compacted (recognises the synthetic list-item datasetId).")
+	@Test
+	void testWithSingleElementListCollapsedByBroker() throws Exception {
+		// Plain-list values are persisted as a multi-instance Property
+		// (PropertyListVO) with one PropertyVO per item, each carrying a
+		// synthetic datasetId prefixed by LIST_ITEM_DATASET_ID_PREFIX.
+		// NGSI-LD brokers MUST preserve multi-instance arrays — but for an
+		// array of one, some brokers (e.g. Scorpio) drop the array wrapper
+		// and return a single Property. We detect that case via the
+		// datasetId prefix and wrap the scalar back into a single-element
+		// list on the way out.
+		List<UnmappedProperty> unmappedProperties = new ArrayList<>();
+		unmappedProperties.add(new UnmappedProperty("dependsOn", List.of("step-cache")));
+
+		MyPojoWithUnmappedProperties expectedPojo = new MyPojoWithUnmappedProperties("urn:ngsi-ld:my-pojo:the-entity");
+		expectedPojo.setMyName("my-name");
+		expectedPojo.setUnmappedProperties(unmappedProperties);
+
+		// Wire format mirrors what Scorpio returns after compacting a
+		// single-instance multi-attribute back to one Property: the
+		// datasetId stays on the Property, the array wrapper is gone.
+		String entityString = "{"
+				+ "\"@context\":\"https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld\","
+				+ "\"id\":\"urn:ngsi-ld:my-pojo:the-entity\","
+				+ "\"type\":\"my-pojo\","
+				+ "\"name\":{\"value\":\"my-name\",\"type\":\"Property\"},"
+				+ "\"dependsOn\":{\"type\":\"Property\",\"datasetId\":\"urn:ngsi-ld:dataset:list-item:0\",\"value\":\"step-cache\"}"
+				+ "}";
+		EntityVO theEntity = OBJECT_MAPPER.readValue(entityString, EntityVO.class);
+
+		MyPojoWithUnmappedProperties myPojoWithUnmappedProperties = entityVOMapper.fromEntityVO(theEntity, MyPojoWithUnmappedProperties.class).block();
+		assertEquals(expectedPojo, myPojoWithUnmappedProperties, "A Property bearing the synthetic list-item datasetId must round-trip as a single-element list.");
+	}
+
+	@DisplayName("Map entity with an unmapped property whose value is an empty list (preserves array shape).")
+	@Test
+	void testWithUnmappedPropertyContainingEmptyList() throws Exception {
+		// Reproduces a bug on the POST side: an empty List used to fall through
+		// the list-handling branch (gated on `!isEmpty()`) and end up in the Map
+		// branch, where toMap(emptyList) returns Map.of(). The PropertyVO's value
+		// was therefore an empty Map ({}) on the wire and on the way back, instead
+		// of an empty array ([]).
+		List<UnmappedProperty> unmappedProperties = new ArrayList<>();
+		unmappedProperties.add(new UnmappedProperty("dependsOn", new ArrayList<>()));
+
+		MyPojoWithUnmappedProperties expectedPojo = new MyPojoWithUnmappedProperties("urn:ngsi-ld:my-pojo:the-entity");
+		expectedPojo.setMyName("my-name");
+		expectedPojo.setUnmappedProperties(unmappedProperties);
+
+		// Wire format mirrors what wistefan now emits on POST: value is an empty
+		// array, not an empty object.
+		String entityString = "{"
+				+ "\"@context\":\"https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld\","
+				+ "\"id\":\"urn:ngsi-ld:my-pojo:the-entity\","
+				+ "\"type\":\"my-pojo\","
+				+ "\"name\":{\"value\":\"my-name\",\"type\":\"Property\"},"
+				+ "\"dependsOn\":{\"type\":\"Property\",\"value\":[]}"
+				+ "}";
+		EntityVO theEntity = OBJECT_MAPPER.readValue(entityString, EntityVO.class);
+
+		MyPojoWithUnmappedProperties myPojoWithUnmappedProperties = entityVOMapper.fromEntityVO(theEntity, MyPojoWithUnmappedProperties.class).block();
+		assertEquals(expectedPojo, myPojoWithUnmappedProperties, "An empty array must round-trip as an empty list, not an empty object.");
+	}
+
+	@DisplayName("Map entity with an unmapped property whose value Map carries a 'value' sub-attribute (preserves the reserved-word key).")
+	@Test
+	void testWithUnmappedPropertyContainingReservedSubAttributeNamedValue() throws Exception {
+		// Reproduces a previously-uncovered collision: when a Map nested inside an
+		// unmapped property has a sub-attribute literally named "value" (one of the
+		// reserved JSON-LD/NGSI-LD names that PropertyVO has an explicit setter for),
+		// the round-trip used to drop it. The wire format carries it as
+		// "tmfEscaped-value" — EscapeCleaningParser used to unescape that to "value"
+		// at parse time, which Jackson then routed straight to PropertyVO.setValue(),
+		// bypassing the @JsonAnySetter that feeds additionalProperties. The "value"
+		// entry never reached EntityVOMapper, so fromProperty emitted only the
+		// surviving siblings.
+		List<UnmappedProperty> unmappedProperties = new ArrayList<>();
+		unmappedProperties.add(new UnmappedProperty(
+				"resourceCharacteristic",
+				Map.of("name", "deploymentName", "valueType", "string", "value", "hello-world-cache")));
+
+		MyPojoWithUnmappedProperties expectedPojo = new MyPojoWithUnmappedProperties("urn:ngsi-ld:my-pojo:the-entity");
+		expectedPojo.setMyName("my-name");
+		expectedPojo.setUnmappedProperties(unmappedProperties);
+
+		// Wire format mirrors what wistefan emits on POST: the structural `value`
+		// field of the outer Property holds the merged map (with the escaped key
+		// inside), and each sub-attribute is also exposed as a sibling Property —
+		// the escaped sibling is the entry that used to be lost.
+		String entityString = "{"
+				+ "\"@context\":\"https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld\","
+				+ "\"id\":\"urn:ngsi-ld:my-pojo:the-entity\","
+				+ "\"type\":\"my-pojo\","
+				+ "\"name\":{\"value\":\"my-name\",\"type\":\"Property\"},"
+				+ "\"resourceCharacteristic\":{"
+				+   "\"type\":\"Property\","
+				+   "\"value\":{\"name\":\"deploymentName\",\"valueType\":\"string\",\"tmfEscaped-value\":\"hello-world-cache\"},"
+				+   "\"name\":{\"type\":\"Property\",\"value\":\"deploymentName\"},"
+				+   "\"valueType\":{\"type\":\"Property\",\"value\":\"string\"},"
+				+   "\"tmfEscaped-value\":{\"type\":\"Property\",\"value\":\"hello-world-cache\"}"
+				+ "}}";
+		EntityVO theEntity = OBJECT_MAPPER.readValue(entityString, EntityVO.class);
+
+		MyPojoWithUnmappedProperties myPojoWithUnmappedProperties = entityVOMapper.fromEntityVO(theEntity, MyPojoWithUnmappedProperties.class).block();
+		assertEquals(expectedPojo, myPojoWithUnmappedProperties,
+				"The 'value' sub-attribute must survive the round-trip — not be swallowed by PropertyVO.value.");
+	}
+
+	@DisplayName("Map entity with an unmapped property containing a nested list of objects (preserves the inner array key).")
+	@Test
+	void testWithUnmappedPropertyContainingNestedListOfObjects() throws Exception {
+		// Reproduces a previously-uncovered case: an unmapped property whose value is a
+		// Map that holds an inner List of Maps under a NAMED key. Before the fix to
+		// fromProperty(...) in EntityVOMapper, the inner array's key was overwritten by
+		// the OUTER property name (the bug renamed e.g. {steps: [...]} → {complex: [...]}
+		// at retrieval time, mirroring the parent's name onto every nested list it held).
+		List<UnmappedProperty> unmappedProperties = new ArrayList<>();
+		unmappedProperties.add(new UnmappedProperty(
+				"complex",
+				Map.of("items", List.of(Map.of("k", "v1"), Map.of("k", "v2")))));
+
+		MyPojoWithUnmappedProperties expectedPojo = new MyPojoWithUnmappedProperties("urn:ngsi-ld:my-pojo:the-entity");
+		expectedPojo.setMyName("my-name");
+		expectedPojo.setUnmappedProperties(unmappedProperties);
+
+		String entityString = "{"
+				+ "\"@context\":\"https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld\","
+				+ "\"id\":\"urn:ngsi-ld:my-pojo:the-entity\","
+				+ "\"type\":\"my-pojo\","
+				+ "\"name\":{\"value\":\"my-name\",\"type\":\"Property\"},"
+				+ "\"complex\":{"
+				+   "\"type\":\"Property\","
+				+   "\"value\":{\"items\":[{\"k\":\"v1\"},{\"k\":\"v2\"}]},"
+				+   "\"items\":["
+				+     "{\"type\":\"Property\",\"value\":{\"k\":\"v1\"},\"k\":{\"type\":\"Property\",\"value\":\"v1\"}},"
+				+     "{\"type\":\"Property\",\"value\":{\"k\":\"v2\"},\"k\":{\"type\":\"Property\",\"value\":\"v2\"}}"
+				+   "]"
+				+ "}}";
+		EntityVO theEntity = OBJECT_MAPPER.readValue(entityString, EntityVO.class);
+
+		MyPojoWithUnmappedProperties myPojoWithUnmappedProperties = entityVOMapper.fromEntityVO(theEntity, MyPojoWithUnmappedProperties.class).block();
+		assertEquals(expectedPojo, myPojoWithUnmappedProperties, "The inner list's key must be preserved (not overwritten by the outer property's name).");
+	}
+
 	@DisplayName("Map Pojo with a field that is an object.")
 	@Test
 	void testSubPropertyMapping() throws JsonProcessingException {

--- a/src/test/java/io/github/wistefan/mapping/desc/JavaObjectMapperTest.java
+++ b/src/test/java/io/github/wistefan/mapping/desc/JavaObjectMapperTest.java
@@ -402,7 +402,12 @@ class JavaObjectMapperTest {
 	@DisplayName("Map entity with an unmapped property list.")
 	@Test
 	void testWithUnmappedPropertiesList() throws Exception {
-		String expectedJson = "{\"@context\":\"https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld\",\"id\":\"urn:ngsi-ld:my-pojo:the-entity\",\"type\":\"my-pojo\",\"name\":{\"value\":\"my-name\",\"type\":\"Property\"},\"test\":{\"value\":[1,2,3],\"type\":\"Property\"}}";
+		// Plain lists are emitted as a multi-instance Property (PropertyListVO),
+		// one PropertyVO per item with a synthetic datasetId. This forces NGSI-LD
+		// brokers to preserve the array shape across JSON-LD compaction — the
+		// older form (Property carrying a JSON array as `value`) was vulnerable
+		// to single-element arrays being scalarised on retrieval.
+		String expectedJson = "{\"@context\":\"https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld\",\"id\":\"urn:ngsi-ld:my-pojo:the-entity\",\"type\":\"my-pojo\",\"name\":{\"value\":\"my-name\",\"type\":\"Property\"},\"test\":[{\"value\":1,\"datasetId\":\"urn:ngsi-ld:dataset:list-item:0\",\"type\":\"Property\"},{\"value\":2,\"datasetId\":\"urn:ngsi-ld:dataset:list-item:1\",\"type\":\"Property\"},{\"value\":3,\"datasetId\":\"urn:ngsi-ld:dataset:list-item:2\",\"type\":\"Property\"}]}";
 		List<UnmappedProperty> unmappedProperties = new ArrayList<>();
 		unmappedProperties.add(new UnmappedProperty("test", List.of(1, 2, 3)));
 
@@ -419,7 +424,7 @@ class JavaObjectMapperTest {
 	@DisplayName("Map entity with multiple unmapped properties.")
 	@Test
 	void testWithMultipleUnmappedProperties() throws Exception {
-		String expectedJson = "{\"@context\":\"https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld\",\"id\":\"urn:ngsi-ld:my-pojo:the-entity\",\"type\":\"my-pojo\",\"name\":{\"value\":\"my-name\",\"type\":\"Property\"},\"other\":{\"value\":\"property\",\"type\":\"Property\"},\"test\":{\"value\":[1,2,3],\"type\":\"Property\"}}";
+		String expectedJson = "{\"@context\":\"https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld\",\"id\":\"urn:ngsi-ld:my-pojo:the-entity\",\"type\":\"my-pojo\",\"name\":{\"value\":\"my-name\",\"type\":\"Property\"},\"other\":{\"value\":\"property\",\"type\":\"Property\"},\"test\":[{\"value\":1,\"datasetId\":\"urn:ngsi-ld:dataset:list-item:0\",\"type\":\"Property\"},{\"value\":2,\"datasetId\":\"urn:ngsi-ld:dataset:list-item:1\",\"type\":\"Property\"},{\"value\":3,\"datasetId\":\"urn:ngsi-ld:dataset:list-item:2\",\"type\":\"Property\"}]}";
 		List<UnmappedProperty> unmappedProperties = new ArrayList<>();
 		unmappedProperties.add(new UnmappedProperty("test", List.of(1, 2, 3)));
 		unmappedProperties.add(new UnmappedProperty("other", "property"));


### PR DESCRIPTION
  Several round-trip failures affected UnmappedProperty values wrapping
  non-trivial structures (Maps with nested lists, lists of plain values,
  sub-attributes whose name collides with NGSI-LD reserved tokens). They
  all surfaced together when modelling a TMF schema-extension carrying a
  small DAG. Fixes bundled together because they only make sense as a set
  — each alone leaves the round-trip broken.

  1. Preserve inner array keys when iterating
     propertyVO.getAdditionalProperties(). The PropertyListVO branch of
     fromProperty was wrapping the result SimpleEntry with the outer key
     parameter instead of entry.getKey(), so a nested array inherited its
     parent's name on retrieval ({outer: {inner: [...]}} came back as
     {outer: {outer: [...]}}).

  2. Preserve reserved-word sub-attributes that collide with VO fields.
     When a Map nested inside an unmapped property held a sub-attribute
     named value, type or id, the round-trip dropped it: the wire format
     carried it as tmfEscaped-<name>, but EscapeCleaningParser unescaped
     it back at Jackson parse time and Jackson then routed the entry to
     the explicit PropertyVO/EntityVO setter, bypassing the
     @JsonAnySetter that feeds additionalProperties. The parser now keeps
     the prefix in place for those three colliding names (see
     ReservedWordHandler.canUnescapeDuringParsing); EntityVOMapper strips
     the prefix when emitting the user-facing keys.

  3. Preserve list values across NGSI-LD broker compaction. Empty lists
     used to fall through the list branch — gated on !isEmpty() — into
     the Map branch and end up persisted as value: {}. Single-element
     plain-value lists were persisted as a Property with value: ["x"],
     which JSON-LD-compacting brokers (e.g. Scorpio) scalarise on
     retrieval. Now empty lists are emitted with an explicit empty-array
     value, and non-empty plain-value lists are emitted as a PropertyList
     with a synthetic datasetId per item
     (urn:ngsi-ld:dataset:list-item:<index>) so multi-instance semantics
     force the broker to preserve the array shape regardless of size.

  4. Restore single-element list semantics from compacted Properties.
     Some brokers still compact a multi-instance Property that has only
     one instance back to a single Property on the wire (the array
     wrapper is dropped). When a Property bears the synthetic list-item
     datasetId prefix, fromProperty now wraps the scalar value back into
     a single-element list — completing list-shape preservation for
     unmapped properties (empty, single and multi-element all round-trip
     correctly).