### PR TITLE
fix(nested-complex-values): round-trip fixes for nested complex values and multi-instance lists

### DIFF
--- a/src/main/java/io/github/wistefan/mapping/EntityVOMapper.java
+++ b/src/main/java/io/github/wistefan/mapping/EntityVOMapper.java
@@ -252,10 +252,18 @@ public class EntityVOMapper extends Mapper {
 		unmappedProperty.setName(ReservedWordHandler.removeEscape(unmappedAdditionalProperty.getKey()));
 
 		if (unmappedAdditionalProperty.getValue() instanceof PropertyListVO propertyListVO) {
+			// PropertyListVO is — by definition — a real multi-instance attribute:
+			// every PropertyVO inside carries a datasetId because NGSI-LD requires
+			// it for multi-instance attributes. Routing each one through fromProperty
+			// would re-trigger the singleton-collapse heuristic
+			// (isCollapsedSingletonListItem returns true on every non-null datasetId)
+			// and wrap each item into a single-element list, turning
+			// [a, b] into [[a], [b]]. We already know we have a list here, so just
+			// extract the raw values. Unescape reserved-word keys in the value
+			// tree so consumers see the original key names.
 			unmappedProperty.setValue(
 					propertyListVO.stream()
-							.map(pvo -> fromProperty(unmappedAdditionalProperty.getKey(), pvo))
-							.map(Map.Entry::getValue)
+							.map(pvo -> unescapeReservedKeys(pvo.getValue()))
 							.toList());
 		} else if (unmappedAdditionalProperty.getValue() instanceof RelationshipListVO relationshipListVO) {
 			unmappedProperty.setValue(
@@ -311,7 +319,30 @@ public class EntityVOMapper extends Mapper {
 
 	private Map.Entry<String, Object> fromProperty(String key, PropertyVO propertyVO) {
 		if (propertyVO.getAdditionalProperties() != null && !propertyVO.getAdditionalProperties().isEmpty()) {
-			return new AbstractMap.SimpleEntry<>(key, propertyVO.getAdditionalProperties().entrySet()
+			// Build the user-facing value by overlaying additionalProperties
+			// siblings on top of the raw Property.value Map. Both sources can
+			// carry useful information:
+			//   - Property.value is the canonical JSON snapshot of the data
+			//     (nested arrays/objects intact, every key present).
+			//   - Siblings (additionalProperties) carry NGSI-LD sub-attribute
+			//     metadata — e.g. multi-instance attributes promoted to
+			//     PropertyListVO with datasetIds, or reserved-word keys
+			//     surfaced via tmfEscaped-* siblings.
+			// Siblings overlay the base because they carry the user-facing
+			// form (an unescape from tmfEscaped-value to value happens here).
+			// Without using value as the base we would lose any key that
+			// JavaObjectMapper deliberately did NOT fan out — in particular
+			// nested lists, which are intentionally kept only inside
+			// Property.value to avoid brokers consolidating a single-element
+			// array back to a scalar.
+			Map<String, Object> merged = new LinkedHashMap<>();
+			Object rawValue = unescapeReservedKeys(propertyVO.getValue());
+			if (rawValue instanceof Map<?, ?> baseMap) {
+				for (Map.Entry<?, ?> e : baseMap.entrySet()) {
+					merged.put(String.valueOf(e.getKey()), e.getValue());
+				}
+			}
+			propertyVO.getAdditionalProperties().entrySet()
 					.stream()
 					.map(entry -> {
 						if (entry.getValue() instanceof PropertyVO pvo) {
@@ -319,9 +350,13 @@ public class EntityVOMapper extends Mapper {
 						} else if (entry.getValue() instanceof RelationshipVO rvo) {
 							return fromRelationship(ReservedWordHandler.removeEscape(entry.getKey()), rvo);
 						} else if (entry.getValue() instanceof PropertyListVO plvo) {
+							// See toUnmappedProperty for the rationale: PropertyListVO
+							// holds real multi-instance items, so extract the raw values
+							// instead of recursing through fromProperty (which would
+							// wrap each item into a single-element list). Also unescape
+							// reserved-word keys in the value tree.
 							List<Object> valueList = plvo.stream()
-									.map(pvo -> fromProperty(entry.getKey(), pvo))
-									.map(Map.Entry::getValue)
+									.map(pvo -> unescapeReservedKeys(pvo.getValue()))
 									.toList();
 							return new AbstractMap.SimpleEntry<>(ReservedWordHandler.removeEscape(entry.getKey()), valueList);
 						} else {
@@ -329,9 +364,10 @@ public class EntityVOMapper extends Mapper {
 						}
 					})
 					.filter(entry -> entry.getValue() != null)
-					.collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
+					.forEach(entry -> merged.put(entry.getKey(), entry.getValue()));
+			return new AbstractMap.SimpleEntry<>(key, merged);
 		} else {
-			Object value = propertyVO.getValue();
+			Object value = unescapeReservedKeys(propertyVO.getValue());
 			if (isCollapsedSingletonListItem(propertyVO)) {
 				value = List.of(value);
 			}
@@ -351,9 +387,9 @@ public class EntityVOMapper extends Mapper {
 	 */
 	private <T> Mono<T> handleProperty(AdditionalPropertyVO propertyValue, T objectUnderConstruction, Method setter, Class<?> parameterType) {
 		if (propertyValue instanceof PropertyVO propertyVO) {
-			return invokeWithExceptionHandling(setter, objectUnderConstruction, objectMapper.convertValue(propertyVO.getValue(), parameterType));
+			return invokeWithExceptionHandling(setter, objectUnderConstruction, objectMapper.convertValue(unescapeReservedKeys(propertyVO.getValue()), parameterType));
 		} else if (propertyValue instanceof GeoPropertyVO geoPropertyVO) {
-			return invokeWithExceptionHandling(setter, objectUnderConstruction, objectMapper.convertValue(geoPropertyVO.getValue(), parameterType));
+			return invokeWithExceptionHandling(setter, objectUnderConstruction, objectMapper.convertValue(unescapeReservedKeys(geoPropertyVO.getValue()), parameterType));
 		} else {
 			log.error("Mapping exception");
 			return Mono.error(new MappingException(String.format("The attribute is not a valid property: %s ", propertyValue)));
@@ -714,11 +750,48 @@ public class EntityVOMapper extends Mapper {
 	private <T> List<T> propertyListToTargetClass(PropertyListVO propertyVOS, Class<T> targetClass) {
 		return propertyVOS.stream().map(propertyEntry -> {
 			try {
-				return objectMapper.convertValue(propertyEntry.getValue(), targetClass);
+				return objectMapper.convertValue(unescapeReservedKeys(propertyEntry.getValue()), targetClass);
 			} catch (IllegalArgumentException e) {
 				return null;
 			}
 		}).filter(Objects::nonNull).toList();
+	}
+
+	/**
+	 * Recursively strip the {@code tmfEscaped-} prefix from any keys in a
+	 * Map/List value tree, returning a copy with the original key names.
+	 *
+	 * <p>Reserved-word keys ({@code id}, {@code value}, {@code type}) arrive
+	 * here still escaped because {@link ReservedWordHandler#canUnescapeDuringParsing}
+	 * deliberately refuses to unescape them at parse time — that protection
+	 * exists so Jackson does not route them to the structural setters on the
+	 * lib's own VO classes ({@code PropertyVO.setValue}, {@code EntityVO.setId},
+	 * …). The protection only matters at the VO layer: once we hand a
+	 * {@code Property.value} payload over to Jackson to materialize a USER
+	 * POJO, an escaped key like {@code tmfEscaped-id} no longer matches any
+	 * field on the target class and the value is silently dropped.
+	 *
+	 * <p>Walk the tree once and surface the original names so the
+	 * {@code objectMapper.convertValue(…, userPojoClass)} call sites can resolve
+	 * them. Non-Map/List values are returned as-is.
+	 */
+	private static Object unescapeReservedKeys(Object value) {
+		if (value instanceof Map<?, ?> map) {
+			Map<String, Object> result = new LinkedHashMap<>(map.size());
+			for (Map.Entry<?, ?> e : map.entrySet()) {
+				String key = String.valueOf(e.getKey());
+				result.put(ReservedWordHandler.removeEscape(key), unescapeReservedKeys(e.getValue()));
+			}
+			return result;
+		}
+		if (value instanceof List<?> list) {
+			List<Object> result = new ArrayList<>(list.size());
+			for (Object item : list) {
+				result.add(unescapeReservedKeys(item));
+			}
+			return result;
+		}
+		return value;
 	}
 
 	/**

--- a/src/main/java/io/github/wistefan/mapping/JavaObjectMapper.java
+++ b/src/main/java/io/github/wistefan/mapping/JavaObjectMapper.java
@@ -483,6 +483,18 @@ public class JavaObjectMapper extends Mapper {
 			Map<String, AdditionalPropertyVO> values = new HashMap<>();
 			objectMap.forEach((key, value) -> {
 				if (key instanceof String stringKey) {
+					// Skip lists nested inside a Map: they would be fan-out as a
+					// PropertyListVO sibling (with one PropertyVO per item, each
+					// bearing a synthetic datasetId). Brokers then consolidate that
+					// multi-instance attribute against the matching key inside our
+					// Property.value Map, collapsing a single-element array back to
+					// its scalar form and breaking the round-trip
+					// (["step-cache"] becomes "step-cache" on retrieval). The list
+					// shape is already preserved by toEscapedMap below, so no
+					// sibling is needed.
+					if (value instanceof List<?>) {
+						return;
+					}
 					propertyVO.setAdditionalProperties(ReservedWordHandler.escapeReservedWords(stringKey), objectToAdditionalProperty(value));
 				}
 

--- a/src/test/java/io/github/wistefan/mapping/desc/EntityVOMapperTest.java
+++ b/src/test/java/io/github/wistefan/mapping/desc/EntityVOMapperTest.java
@@ -229,6 +229,37 @@ class EntityVOMapperTest {
 		assertEquals(expectedPojo, myPojoWithUnmappedProperties, "A Property bearing the synthetic list-item datasetId must round-trip as a single-element list.");
 	}
 
+	@DisplayName("Reconstruct a multi-element list from a real multi-instance Property (does NOT wrap each item).")
+	@Test
+	void testWithMultiInstancePropertyList() throws Exception {
+		// Companion case to testWithSingleElementListCollapsedByBroker.
+		// When the wire format carries a TRUE multi-instance attribute (an array of
+		// PropertyVO, one per item), every item legitimately has a datasetId
+		// because NGSI-LD requires it for multi-instance attributes. The
+		// "datasetId-means-singleton-compacted" heuristic must NOT fire here:
+		// otherwise the round-trip turns ["a", "b"] into [["a"], ["b"]].
+		List<UnmappedProperty> unmappedProperties = new ArrayList<>();
+		unmappedProperties.add(new UnmappedProperty("extensionArray", List.of("a", "b")));
+
+		MyPojoWithUnmappedProperties expectedPojo = new MyPojoWithUnmappedProperties("urn:ngsi-ld:my-pojo:the-entity");
+		expectedPojo.setMyName("my-name");
+		expectedPojo.setUnmappedProperties(unmappedProperties);
+
+		String entityString = "{"
+				+ "\"@context\":\"https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld\","
+				+ "\"id\":\"urn:ngsi-ld:my-pojo:the-entity\","
+				+ "\"type\":\"my-pojo\","
+				+ "\"name\":{\"value\":\"my-name\",\"type\":\"Property\"},"
+				+ "\"extensionArray\":["
+				+   "{\"type\":\"Property\",\"datasetId\":\"urn:ngsi-ld:dataset:list-item:0\",\"value\":\"a\"},"
+				+   "{\"type\":\"Property\",\"datasetId\":\"urn:ngsi-ld:dataset:list-item:1\",\"value\":\"b\"}"
+				+ "]}";
+		EntityVO theEntity = OBJECT_MAPPER.readValue(entityString, EntityVO.class);
+
+		MyPojoWithUnmappedProperties actual = entityVOMapper.fromEntityVO(theEntity, MyPojoWithUnmappedProperties.class).block();
+		assertEquals(expectedPojo, actual, "A real multi-instance attribute must round-trip as a flat list, not a list-of-singletons.");
+	}
+
 	@DisplayName("Map entity with an unmapped property whose value is an empty list (preserves array shape).")
 	@Test
 	void testWithUnmappedPropertyContainingEmptyList() throws Exception {
@@ -337,6 +368,98 @@ class EntityVOMapperTest {
 
 		MyPojoWithUnmappedProperties myPojoWithUnmappedProperties = entityVOMapper.fromEntityVO(theEntity, MyPojoWithUnmappedProperties.class).block();
 		assertEquals(expectedPojo, myPojoWithUnmappedProperties, "The inner list's key must be preserved (not overwritten by the outer property's name).");
+	}
+
+	@DisplayName("Map Pojo with a mapped sub-property whose nested object carries reserved-word fields (id/value/type).")
+	@Test
+	void testSubPropertyWithNestedReservedFieldsRoundTrip() throws Exception {
+		// Reproduces the TMForum *RefOrValue regression after the
+		// VO_FIELD_COLLISIONS guard was added: a parent entity has a
+		// @AttributeSetter(PROPERTY) field whose Java type is a complex object
+		// holding reserved-word fields (id, value, type). On the wire those keys
+		// are escaped (tmfEscaped-id, …) so the EscapeCleaningParser does NOT
+		// route them to PropertyVO.setValue / EntityVO.setId. But by the time we
+		// hand the Property.value Map to objectMapper.convertValue(...) to
+		// materialize the USER POJO, the escape is in the way — Jackson can't
+		// find a field literally called "tmfEscaped-id" on the target class and
+		// silently drops the value. EntityVOMapper.handleProperty must surface
+		// the original names before delegating to Jackson.
+		MySubPropertyRefOrValue expectedSub = new MySubPropertyRefOrValue();
+		expectedSub.setId(URI.create("urn:ref:42"));
+		expectedSub.setHref(URI.create("http://my-ref.de"));
+		expectedSub.setValue("the-value");
+		expectedSub.setType("the-type");
+		expectedSub.setName("the-name");
+
+		MyPojoWithSubPropertyRefOrValue expectedPojo = new MyPojoWithSubPropertyRefOrValue("urn:ngsi-ld:complex-pojo:the-test-pojo");
+		expectedPojo.setMyRefOrValue(expectedSub);
+
+		String entityString = "{"
+				+ "\"@context\":\"https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld\","
+				+ "\"id\":\"urn:ngsi-ld:complex-pojo:the-test-pojo\","
+				+ "\"type\":\"complex-pojo\","
+				+ "\"myRefOrValue\":{"
+				+   "\"type\":\"Property\","
+				+   "\"value\":{"
+				+     "\"tmfEscaped-id\":\"urn:ref:42\","
+				+     "\"href\":\"http://my-ref.de\","
+				+     "\"tmfEscaped-value\":\"the-value\","
+				+     "\"tmfEscaped-type\":\"the-type\","
+				+     "\"name\":\"the-name\""
+				+   "}"
+				+ "}}";
+		EntityVO theEntity = OBJECT_MAPPER.readValue(entityString, EntityVO.class);
+
+		MyPojoWithSubPropertyRefOrValue actual = entityVOMapper.fromEntityVO(theEntity, MyPojoWithSubPropertyRefOrValue.class).block();
+		assertEquals(expectedPojo, actual, "Reserved-word fields nested inside a mapped property must round-trip.");
+	}
+
+	@DisplayName("Map Pojo with a mapped property-list whose elements carry reserved-word fields (id/value/type).")
+	@Test
+	void testPropertyListWithNestedReservedFieldsRoundTrip() throws Exception {
+		// Same regression as the sub-property variant, exercised through the
+		// PROPERTY_LIST code path (handlePropertyList → propertyListToTargetClass).
+		MySubPropertyRefOrValue expectedSub1 = new MySubPropertyRefOrValue();
+		expectedSub1.setId(URI.create("urn:ref:1"));
+		expectedSub1.setHref(URI.create("http://my-ref.de/1"));
+		expectedSub1.setValue("value-1");
+		expectedSub1.setType("type-1");
+		expectedSub1.setName("name-1");
+
+		MySubPropertyRefOrValue expectedSub2 = new MySubPropertyRefOrValue();
+		expectedSub2.setId(URI.create("urn:ref:2"));
+		expectedSub2.setHref(URI.create("http://my-ref.de/2"));
+		expectedSub2.setValue("value-2");
+		expectedSub2.setType("type-2");
+		expectedSub2.setName("name-2");
+
+		MyPojoWithSubPropertyRefOrValue expectedPojo = new MyPojoWithSubPropertyRefOrValue("urn:ngsi-ld:complex-pojo:the-test-pojo");
+		expectedPojo.setMyRefOrValueList(List.of(expectedSub1, expectedSub2));
+
+		String entityString = "{"
+				+ "\"@context\":\"https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld\","
+				+ "\"id\":\"urn:ngsi-ld:complex-pojo:the-test-pojo\","
+				+ "\"type\":\"complex-pojo\","
+				+ "\"myRefOrValueList\":["
+				+   "{\"type\":\"Property\",\"value\":{"
+				+     "\"tmfEscaped-id\":\"urn:ref:1\","
+				+     "\"href\":\"http://my-ref.de/1\","
+				+     "\"tmfEscaped-value\":\"value-1\","
+				+     "\"tmfEscaped-type\":\"type-1\","
+				+     "\"name\":\"name-1\""
+				+   "}},"
+				+   "{\"type\":\"Property\",\"value\":{"
+				+     "\"tmfEscaped-id\":\"urn:ref:2\","
+				+     "\"href\":\"http://my-ref.de/2\","
+				+     "\"tmfEscaped-value\":\"value-2\","
+				+     "\"tmfEscaped-type\":\"type-2\","
+				+     "\"name\":\"name-2\""
+				+   "}}"
+				+ "]}";
+		EntityVO theEntity = OBJECT_MAPPER.readValue(entityString, EntityVO.class);
+
+		MyPojoWithSubPropertyRefOrValue actual = entityVOMapper.fromEntityVO(theEntity, MyPojoWithSubPropertyRefOrValue.class).block();
+		assertEquals(expectedPojo, actual, "Reserved-word fields inside a mapped property-list element must round-trip.");
 	}
 
 	@DisplayName("Map Pojo with a field that is an object.")

--- a/src/test/java/io/github/wistefan/mapping/desc/JavaObjectMapperTest.java
+++ b/src/test/java/io/github/wistefan/mapping/desc/JavaObjectMapperTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import java.net.URI;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
@@ -397,6 +398,77 @@ class JavaObjectMapperTest {
 		assertEquals(expectedJson,
 				OBJECT_MAPPER.writeValueAsString(javaObjectMapper.toEntityVO(myPojoWithUnmappedProperties)),
 				"The pojo should have been translated into a valid entity");
+	}
+
+	@DisplayName("Map entity with a deeply nested list inside a Map-of-list-of-maps (reproduces the orchestrationPlan blueprint shape).")
+	@Test
+	void testDeepNestedListInsideMapOfListOfMaps() throws Exception {
+		// Reproduces the TMForum Blueprint shape:
+		//   orchestrationPlan: { steps: [ { id: ..., dependsOn: [..] }, ... ], version: "1.0" }
+		// The bug to be guarded against: when serialising for POST, the
+		// single-element nested list (dependsOn: ["step-cache"]) MUST stay a
+		// JSON array — not be flattened to a scalar — so the broker stores it
+		// as an array and the round-trip preserves the shape.
+		LinkedHashMap<String, Object> step1 = new LinkedHashMap<>();
+		step1.put("id", "step-cache");
+		step1.put("dependsOn", List.of());
+
+		LinkedHashMap<String, Object> step2 = new LinkedHashMap<>();
+		step2.put("id", "step-web");
+		step2.put("dependsOn", List.of("step-cache"));
+
+		LinkedHashMap<String, Object> orchestrationPlan = new LinkedHashMap<>();
+		orchestrationPlan.put("steps", List.of(step1, step2));
+		orchestrationPlan.put("version", "1.0");
+
+		List<UnmappedProperty> unmappedProperties = new ArrayList<>();
+		unmappedProperties.add(new UnmappedProperty("orchestrationPlan", orchestrationPlan));
+
+		MyPojoWithUnmappedProperties pojo = new MyPojoWithUnmappedProperties("urn:ngsi-ld:my-pojo:the-entity");
+		pojo.setMyName("my-name");
+		pojo.setUnmappedProperties(unmappedProperties);
+
+		String json = OBJECT_MAPPER.writeValueAsString(javaObjectMapper.toEntityVO(pojo));
+		// The serialised JSON sent to the broker MUST contain the array form
+		// — not the scalar "step-cache" — for dependsOn.
+		assertTrue(json.contains("\"dependsOn\":[\"step-cache\"]"),
+				"dependsOn must round-trip as a JSON array in the wire payload, but was: " + json);
+		assertFalse(json.contains("\"dependsOn\":\"step-cache\""),
+				"dependsOn must NOT be flattened to a scalar in the wire payload, but was: " + json);
+	}
+
+	@DisplayName("Map entity with a Map-valued unmapped property containing a nested list (no fan-out sibling for the list).")
+	@Test
+	void testWithUnmappedPropertyMapContainingNestedList() throws Exception {
+		// Companion to the read-side regression in EntityVOMapperTest: when a
+		// Map-valued unmapped property carries a nested list (e.g.
+		// orchestrationPlan.step.dependsOn = ["step-cache"]), the list MUST NOT
+		// be promoted to a sibling multi-instance attribute (PropertyListVO with
+		// synthetic datasetIds). Brokers consolidate that sibling against the
+		// matching key inside Property.value and collapse single-element arrays
+		// to scalars, breaking the round-trip ("step-cache" instead of
+		// ["step-cache"]). The list shape lives in Property.value alone.
+		// Non-list keys still get the fan-out sibling.
+		String expectedJson = "{\"@context\":\"https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld\","
+				+ "\"id\":\"urn:ngsi-ld:my-pojo:the-entity\",\"type\":\"my-pojo\","
+				+ "\"complex\":{"
+				+   "\"value\":{\"myList\":[\"a\"],\"simpleString\":\"x\"},"
+				+   "\"type\":\"Property\","
+				+   "\"simpleString\":{\"value\":\"x\",\"type\":\"Property\"}"
+				+ "},"
+				+ "\"name\":{\"value\":\"my-name\",\"type\":\"Property\"}}";
+		List<UnmappedProperty> unmappedProperties = new ArrayList<>();
+		unmappedProperties.add(new UnmappedProperty(
+				"complex",
+				Map.of("simpleString", "x", "myList", List.of("a"))));
+
+		MyPojoWithUnmappedProperties pojo = new MyPojoWithUnmappedProperties("urn:ngsi-ld:my-pojo:the-entity");
+		pojo.setMyName("my-name");
+		pojo.setUnmappedProperties(unmappedProperties);
+
+		assertEquals(expectedJson,
+				OBJECT_MAPPER.writeValueAsString(javaObjectMapper.toEntityVO(pojo)),
+				"Nested lists inside a Map-valued unmapped property must stay in Property.value and never appear as a multi-instance sibling.");
 	}
 
 	@DisplayName("Map entity with an unmapped property list.")

--- a/src/test/java/io/github/wistefan/mapping/desc/pojos/MyPojoWithSubPropertyRefOrValue.java
+++ b/src/test/java/io/github/wistefan/mapping/desc/pojos/MyPojoWithSubPropertyRefOrValue.java
@@ -1,0 +1,42 @@
+package io.github.wistefan.mapping.desc.pojos;
+
+import io.github.wistefan.mapping.annotations.AttributeGetter;
+import io.github.wistefan.mapping.annotations.AttributeSetter;
+import io.github.wistefan.mapping.annotations.AttributeType;
+import io.github.wistefan.mapping.annotations.EntityId;
+import io.github.wistefan.mapping.annotations.EntityType;
+import io.github.wistefan.mapping.annotations.MappingEnabled;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.net.URI;
+import java.util.List;
+
+/**
+ * Mirrors the TMForum shape that broke after 1.6.14: a parent entity whose
+ * {@code @AttributeSetter(PROPERTY)} field is a complex object holding a
+ * nested ref-or-value with reserved-word keys.
+ */
+@MappingEnabled(entityType = "complex-pojo")
+@EqualsAndHashCode
+public class MyPojoWithSubPropertyRefOrValue {
+
+	@Getter(onMethod = @__({@EntityId}))
+	private URI id;
+
+	@Getter(onMethod = @__({@EntityType}))
+	private String type = "complex-pojo";
+
+	public MyPojoWithSubPropertyRefOrValue(String id) {
+		this.id = URI.create(id);
+	}
+
+	@Getter(onMethod = @__({@AttributeGetter(value = AttributeType.PROPERTY, targetName = "myRefOrValue")}))
+	@Setter(onMethod = @__({@AttributeSetter(value = AttributeType.PROPERTY, targetName = "myRefOrValue")}))
+	private MySubPropertyRefOrValue myRefOrValue;
+
+	@Getter(onMethod = @__({@AttributeGetter(value = AttributeType.PROPERTY_LIST, targetName = "myRefOrValueList")}))
+	@Setter(onMethod = @__({@AttributeSetter(value = AttributeType.PROPERTY_LIST, targetName = "myRefOrValueList", targetClass = MySubPropertyRefOrValue.class)}))
+	private List<MySubPropertyRefOrValue> myRefOrValueList;
+}

--- a/src/test/java/io/github/wistefan/mapping/desc/pojos/MySubPropertyRefOrValue.java
+++ b/src/test/java/io/github/wistefan/mapping/desc/pojos/MySubPropertyRefOrValue.java
@@ -1,0 +1,24 @@
+package io.github.wistefan.mapping.desc.pojos;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+import java.net.URI;
+
+/**
+ * Models the TMForum {@code *RefOrValue} pattern: a nested object exposing
+ * reserved-word fields ({@code id}, {@code value}, {@code type}) alongside
+ * other attributes. Used to exercise that those fields survive the
+ * round-trip when the enclosing attribute is mapped through
+ * {@link io.github.wistefan.mapping.annotations.AttributeType#PROPERTY}.
+ */
+@EqualsAndHashCode
+@Data
+public class MySubPropertyRefOrValue {
+
+	private URI id;
+	private URI href;
+	private String value;
+	private String type;
+	private String name;
+}


### PR DESCRIPTION
Three regressions surfaced after the 1.6.14 reserved-word work
  (commits ef08f9b / fd41727 on the fix-nested-array-keys branch):

  1. Nested *RefOrValue POJOs lose id / value / type on retrieval.
     The VO_FIELD_COLLISIONS guard in ReservedWordHandler correctly
     stops EscapeCleaningParser from routing tmfEscaped-{id,value,type}
     to the structural setters on PropertyVO / EntityVO, but the escape
     then survives inside Property.value Maps. When EntityVOMapper
     hands those Maps to objectMapper.convertValue(..., userPojoClass)
     the conversion goes through TokenBuffer (not EscapeCleaningParser),
     so Jackson looks for a literal "tmfEscaped-id" field on the target
     class and silently drops the value.

     Fix: a recursive unescapeReservedKeys(...) helper that strips the
     tmfEscaped- prefix from Map / List value trees. Applied at the
     user-POJO convertValue call sites in handleProperty and
     propertyListToTargetClass; also at the read-back points in
     fromProperty (both branches) and toUnmappedProperty. The
     VO-targeted convertValue calls are untouched, so the
     @JsonAnySetter routing for additionalProperties named
     id / value / type still works.

  2. Real multi-instance lists [a, b] become [[a], [b]] on the way back.
     fd41727 simplified isCollapsedSingletonListItem to "datasetId != null",
     which is right for a PropertyVO arriving on its own (a broker-
     compacted singleton) but wrong when iterating a real PropertyListVO —
     every item there legitimately carries a datasetId because NGSI-LD
     requires it for multi-instance attributes. Routing each one through
     fromProperty re-triggered the wrap.

     Fix: in toUnmappedProperty and fromProperty's nested
     additionalProperties branch, extract PropertyVO.getValue() raw
     (with key unescape) when iterating a PropertyListVO.

  3. Nested single-element lists inside Map-valued unmapped properties
     round-trip as scalars (orchestrationPlan.steps[].dependsOn case).
     The fan-out in objectToAdditionalProperty(Map) promoted every Map
     value — including Lists — to a sibling sub-Property. For
     single-element plain lists that turned into a PropertyListVO with
     one PropertyVO bearing a datasetId, which NGSI-LD brokers then
     consolidate against the matching key inside Property.value,
     collapsing ["step-cache"] back to "step-cache".

     Fix: in objectToAdditionalProperty's Map ELSE branch, skip the
     fan-out sibling when the value is a List. The list shape is
     already preserved inside toEscapedMap(objectMap), so no sibling
     is needed. Top-level lists keep their PropertyListVO + datasetId
     form (which is what protects them from JSON-LD compaction).