### PR TITLE
fix(deserializer): handle opaque values in AdditionalPropertyDeserializer

### DIFF
--- a/src/main/java/io/github/wistefan/mapping/AdditionalPropertyDeserializer.java
+++ b/src/main/java/io/github/wistefan/mapping/AdditionalPropertyDeserializer.java
@@ -5,11 +5,14 @@ import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.util.TokenBuffer;
 import com.fasterxml.jackson.databind.jsontype.TypeIdResolver;
 import com.fasterxml.jackson.databind.jsontype.impl.AsArrayTypeDeserializer;
 import com.fasterxml.jackson.databind.jsontype.impl.AsPropertyTypeDeserializer;
 import com.fasterxml.jackson.databind.type.TypeFactory;
 import org.fiware.ngsi.model.*;
+
+import java.util.Set;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -20,6 +23,8 @@ import java.util.List;
  * It can differentiate between list and object type properties and handle them with the fitting serializer.
  */
 public class AdditionalPropertyDeserializer extends AsArrayTypeDeserializer {
+
+	private static final Set<String> NGSI_LD_TYPES = Set.of("Property", "GeoProperty", "Relationship");
 
 	/**
 	 * Default property-type deserializer can be used for the individual objects.
@@ -47,13 +52,56 @@ public class AdditionalPropertyDeserializer extends AsArrayTypeDeserializer {
 				return _deserializeWithNativeTypeId(p, ctxt, typeId);
 			}
 		}
+
+		// Handle primitive values that cannot be NGSI-LD properties.
+		// These occur when complex Java objects with plain-typed fields are stored as
+		// NGSI-LD sub-properties (e.g. a Characteristic value containing a nested object
+		// whose fields happen to be named "type" or "properties").
+		JsonToken currentToken = p.currentToken();
+		if (currentToken == JsonToken.VALUE_STRING) {
+			return new PropertyVO().value(p.getText());
+		} else if (currentToken == JsonToken.VALUE_NUMBER_INT) {
+			return new PropertyVO().value(p.getLongValue());
+		} else if (currentToken == JsonToken.VALUE_NUMBER_FLOAT) {
+			return new PropertyVO().value(p.getDoubleValue());
+		} else if (currentToken == JsonToken.VALUE_TRUE || currentToken == JsonToken.VALUE_FALSE) {
+			return new PropertyVO().value(p.getBooleanValue());
+		} else if (currentToken == JsonToken.VALUE_NULL) {
+			return null;
+		}
+
 		// if no type id is present we need the next token to decide if its an object or an array
 		JsonToken t = p.nextToken();
 		// case FIELD_NAME:
 		// If the token is of type FIELD_NAME, no START_ARRAY was present, thus we can take the
 		// object and directly serialize it with the standard deserializer
 		if (t == JsonToken.FIELD_NAME) {
-			return additionalPropertyObjectDeser.deserializeTypedFromObject(p, ctxt);
+			// Buffer the full object so we can peek for the NGSI-LD "type" discriminator
+			// before committing to the typed deserializer. Without this, a plain JSON object
+			// (e.g. a Characteristic value whose fields are named "type" or "properties")
+			// causes an InvalidTypeIdException.
+			TokenBuffer buffer = new TokenBuffer(p, ctxt);
+			buffer.writeStartObject();
+			while (p.currentToken() != JsonToken.END_OBJECT && p.currentToken() != null) {
+				String fieldName = p.currentName();
+				buffer.writeFieldName(fieldName);
+				p.nextToken();
+				buffer.copyCurrentStructure(p);
+				p.nextToken();
+			}
+			buffer.writeEndObject();
+
+			// Peek: is the "type" field present with a valid NGSI-LD value?
+			if (hasNgsiLdType(buffer)) {
+				JsonParser bp = buffer.asParserOnFirstToken();
+				bp.nextToken(); // START_OBJECT -> FIELD_NAME
+				return additionalPropertyObjectDeser.deserializeTypedFromObject(bp, ctxt);
+			} else {
+				// Plain object — not an NGSI-LD property. Wrap its value in a PropertyVO.
+				JsonParser bp = buffer.asParserOnFirstToken();
+				Object plainValue = ctxt.readValue(bp, Object.class);
+				return new PropertyVO().value(plainValue);
+			}
 		}
 		// case START_OBJECT
 		// If a start-object(e.g. '{') token is present, a START_ARRAY was present and we have at least one
@@ -66,6 +114,27 @@ public class AdditionalPropertyDeserializer extends AsArrayTypeDeserializer {
 		}
 
 		return super._deserialize(p, ctxt);
+	}
+
+	/**
+	 * Peek inside a TokenBuffer to check whether the buffered object contains a "type"
+	 * field whose value is a valid NGSI-LD property type (Property, GeoProperty, Relationship).
+	 */
+	private boolean hasNgsiLdType(TokenBuffer buffer) throws IOException {
+		JsonParser peek = buffer.asParserOnFirstToken();
+		// START_OBJECT
+		while (peek.nextToken() == JsonToken.FIELD_NAME) {
+			String name = peek.currentName();
+			JsonToken valueToken = peek.nextToken();
+			if (AdditionalPropertyTypeResolver.NGSI_LD_TYPE_PROPERTY_NAME.equals(name)
+					&& valueToken == JsonToken.VALUE_STRING
+					&& NGSI_LD_TYPES.contains(peek.getText())) {
+				return true;
+			}
+			// Skip the value (could be object/array)
+			peek.skipChildren();
+		}
+		return false;
 	}
 
 	/**


### PR DESCRIPTION
When a complex Java object whose fields include NGSI-LD reserved names
("type", "properties") is stored as a characteristic value, the library
serialises those fields as NGSI-LD sub-properties.  On read-back,
AdditionalPropertyDeserializer received tokens that were plain primitives
or plain JSON objects without an NGSI-LD "type" discriminator, causing an
InvalidTypeIdException.

Two changes, both backwards-compatible (previously these paths always
threw):

1. Primitive tokens (VALUE_STRING, VALUE_NUMBER, VALUE_TRUE/FALSE, NULL)
   arriving at _deserialize are now wrapped in a PropertyVO instead of
   consuming the wrong next token and failing.

2. Object tokens (FIELD_NAME branch) are buffered and inspected for the
   NGSI-LD "type" field before dispatching to the typed deserialiser.
   Objects without a valid NGSI-LD type (Property/GeoProperty/Relationship)
   are deserialised as plain Object and wrapped in a PropertyVO.