### PR TITLE
feat: return HttpResponse instead of the plain body in generated clients

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -412,7 +412,7 @@
                                 <clientId>ngsi</clientId>
                                 <fullJavaUtil>true</fullJavaUtil>
                                 <useOptional>false</useOptional>
-                                <useGenericResponse>false</useGenericResponse>
+                                <useGenericResponse>true</useGenericResponse>
                                 <useLombokGenerated>true</useLombokGenerated>
                                 <introspected>true</introspected>
                                 <generateAliasAsModel>false</generateAliasAsModel>


### PR DESCRIPTION
Some implementations need access to the response headers, not just the body, so the generated NGSI-LD API clients now return Mono<HttpResponse<T>> instead of Mono<T>.

It's a breaking change